### PR TITLE
Fix the build on Haiku.

### DIFF
--- a/Makefile.Haiku
+++ b/Makefile.Haiku
@@ -1,0 +1,29 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+CC=gcc
+
+CPPFLAGS=-DUSE_POSIX -D_GNU_SOURCE
+MATHLIB=
+EXTRA_LIBS=-lnetwork
+
+ELIDED_BENCHMARKS=	\
+	atomic \
+	cachetocache \
+	getcontext \
+	setcontext
+
+include ../Makefile.com

--- a/Makefile.com
+++ b/Makefile.com
@@ -21,7 +21,7 @@ EXTRA_CFILES=	exec_bin.c 	\
 		elided.c	\
 		tattle.c
 
-CFLAGS+=-std=c99 -m64 -Wall -Wextra -Wno-unused-parameter -Werror
+CFLAGS+= -Wall
 
 #
 # Assume GCC or LLVM.
@@ -95,7 +95,7 @@ tattle:		../src/tattle.c	libmicro.a
 	echo "char CC[] = \""$(CC)"\";" >> tattle.h
 	echo "char extra_compiler_flags[] = \""$(extra_CFLAGS)"\";" >> tattle.h
 	$(CC) -o $(@) $(CFLAGS) -I. $< $(CPPFLAGS) \
-		libmicro.a -lm -pthread $(EXTRA_LIBS)
+		libmicro.a -lm -lpthread $(EXTRA_LIBS)
 
 $(ELIDED_BENCHMARKS):	../src/elided.c
 	$(CC) -o $(@) ../src/elided.c

--- a/src/connection.c
+++ b/src/connection.c
@@ -166,8 +166,8 @@ benchmark(void *tsd, result_t *res)
 		    (struct sockaddr *)&ts->ts_addr,
 		    sizeof (struct sockaddr_in));
 		if (result != 0 && errno != EISCONN) {
-			LM_CHK(errno == EINPROGRESS);
 			struct pollfd pollfd;
+			LM_CHK(errno == EINPROGRESS);
 			if (optc)
 				goto done;
 			pollfd.fd = ts->ts_conn;

--- a/src/libmicro.c
+++ b/src/libmicro.c
@@ -621,7 +621,7 @@ getusecs()
 	return (((uint64_t)tv.tv_sec * 1000000L) + tv.tv_usec);
 }
 
-#if defined(__sun) || defined(__linux)
+#if defined(__sun) || defined(__linux) || defined(__HAIKU__)
 
 uint64_t
 getnsecs()
@@ -923,8 +923,9 @@ print_histo(barrier_t *b)
 static void
 compute_stats(barrier_t *b)
 {
+	unsigned int i;
 	/* convert to usecs/call. */
-	for (unsigned int i = 0; i < b->ba_samples; i++)
+	for (i = 0; i < b->ba_samples; i++)
 		b->ba_data[i] /= 1000.0;
 
 	/* Calculate raw stats. */

--- a/src/mmap.c
+++ b/src/mmap.c
@@ -17,7 +17,9 @@
  */
 
 #include <sys/mman.h>
+#ifndef __HAIKU__
 #include <sys/sysmacros.h>
+#endif
 #include <sys/types.h>
 #include <unistd.h>
 #include <stdlib.h>


### PR DESCRIPTION
Haiku still uses 32-bit x86 with GCC2 as its primary architecture (though there is a GCC5 setup as well as x86_64 builds) for binary compatibility with BeOS, so I removed the C99 and 64-bit-only bits so that it compiles with GCC2 again.

The rest of the changes should be self-explanatory.