### PR TITLE
Fix potential overflow of opstr

### DIFF
--- a/src/libmicro.c
+++ b/src/libmicro.c
@@ -102,7 +102,7 @@ actual_main(int argc, char *argv[])
 	int			opt;
 	extern char		*optarg;
 	char			*tmp;
-	char			optstr[256];
+	char			optstr[2048];
 	barrier_t		*b;
 	long long		startnsecs;
 


### PR DESCRIPTION
```
../src/libmicro.c:156:51: error: ‘%s’ directive writing up to 2047 bytes into a region of size 231 [-Werror=format-overflow=]
  156 |  (void) sprintf(optstr, "1AB:C:D:EHI:LMN:P:RST:VW?%s", lm_optstr);
      |                                                   ^~   ~~~~~~~~~
../src/libmicro.c:156:9: note: ‘sprintf’ output between 26 and 2073 bytes into a destination of size 256
  156 |  (void) sprintf(optstr, "1AB:C:D:EHI:LMN:P:RST:VW?%s", lm_optstr);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```